### PR TITLE
Fix Restricted Extra Install, Handle Desktop Icons better

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: edamame
-Version: 2.7.6
+Version: 2.7.7
 Maintainer: Thomas Castleman <batcastle@draugeros.org>
 Homepage: https://github.com/drauger-os-development/edamame
 Section: admin

--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: edamame
-Version: 2.7.7
+Version: 2.7.8
 Maintainer: Thomas Castleman <batcastle@draugeros.org>
 Homepage: https://github.com/drauger-os-development/edamame
 Section: admin

--- a/usr/bin/edamame.cxx
+++ b/usr/bin/edamame.cxx
@@ -46,7 +46,7 @@
 
 using namespace std;
 
-str VERSION = "2.7.6";
+str VERSION = "2.7.7";
 str R = "\033[0;31m";
 str G = "\033[0;32m";
 str Y = "\033[1;33m";

--- a/usr/bin/edamame.cxx
+++ b/usr/bin/edamame.cxx
@@ -46,7 +46,7 @@
 
 using namespace std;
 
-str VERSION = "2.7.7";
+str VERSION = "2.7.8";
 str R = "\033[0;31m";
 str G = "\033[0;32m";
 str Y = "\033[1;33m";

--- a/usr/share/edamame/modules/install_extras.py
+++ b/usr/share/edamame/modules/install_extras.py
@@ -97,7 +97,7 @@ def install_extras():
     # Make sure our cache is up to date and open
     cache = apt.cache.Cache()
     cache.update()
-    # cache.open()
+    cache.open()
     NVIDIA = False
     # Check PCI list
     pci = subproc.check_output(["lspci", "-q"]).decode()

--- a/usr/share/edamame/modules/install_extras.py
+++ b/usr/share/edamame/modules/install_extras.py
@@ -27,6 +27,7 @@ from sys import stderr
 import apt
 import subprocess as subproc
 import urllib3
+import os
 
 import modules.purge as purge
 
@@ -137,6 +138,7 @@ def install_extras():
         else:
             install_list.append("nvidia-driver-latest")
     # Install everything we want
+    os.environ["DEBIAN_FRONTEND"] = "noninteractive"
     subproc.check_call(["apt-get", "install", "-o", "Dpkg::Options::='--force-confold'", "--force-yes", "-y"] + install_list)
     # Purge all the stuff we don't want
     purge.purge_package("gstreamer1.0-fluendo-mp3")

--- a/usr/share/edamame/modules/install_extras.py
+++ b/usr/share/edamame/modules/install_extras.py
@@ -139,8 +139,12 @@ def install_extras():
             install_list.append("nvidia-driver-latest")
     # Install everything we want
     os.environ["DEBIAN_FRONTEND"] = "noninteractive"
-    subproc.check_call(["apt-get", "install", "-o", "Dpkg::Options::='--force-confold'", "--force-yes", "-y"] + install_list)
+    with cache.actiongroup():
+        for each in install_list:
+            cache[each].mark_install()
+    #subproc.check_call(["apt-get", "install", "-o", "Dpkg::Options::='--force-confold'", "--force-yes", "-y"] + install_list)
     # Purge all the stuff we don't want
+    cache.commit()
     purge.purge_package("gstreamer1.0-fluendo-mp3")
     cache.close()
     __eprint__("    ###    install_extras.py CLOSED    ###    ")

--- a/usr/share/edamame/modules/verify_install.py
+++ b/usr/share/edamame/modules/verify_install.py
@@ -127,7 +127,10 @@ def verify(username, root, distro):
     try:
         os.remove("/home/" + username + "/Desktop/edamame.desktop")
     except FileNotFoundError:
-        pass
+        try:
+            os.remove("/home/" + username + "/Desktop/system-installer.desktop")
+        except FileNotFoundError:
+            pass
     if auto_partitioner.is_EFI():
         # on UEFI, set as default entry
         status = is_default_entry(distro)


### PR DESCRIPTION
 - Fix bug with Restricted Extra installation failing
 - Allow desktop icons to be named `edamame.desktop` or `system-installer.desktop`